### PR TITLE
Make it Python 3.10 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+.DS_Store

--- a/RPi/GPIO.py
+++ b/RPi/GPIO.py
@@ -1,5 +1,10 @@
-from collections import Sequence
-
+try:
+    # using Python 3.10+
+    from collections.abc import Sequence
+except ImportError:
+    # using Python 3.10-
+    from collections import Sequence
+    
 from . import __version__
 from . import pin as pins
 from .launcher import ui


### PR DESCRIPTION
Starting with Python 3.10 the Sequence class has been moved to the "collections.abc" module.
Updated the code to make it compatible with python 3.10+  